### PR TITLE
ci: use `ssh-agent` for AUR SSH key

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -43,11 +43,22 @@ jobs:
             aur.archlinux.org ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLMiLrP8pVi5BFX2i3vepSUnpedeiewE5XptnUnau+ZoeUOPkpoCgZZuYfpaIQfhhJJI5qgnjJmr4hyJbe/zxow=
             aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN
 
-      - run: echo "$AUR_SSH_KEY" > ~/.ssh/aur && chmod 600 ~/.ssh/aur
+      - id: ssh-agent
+        run: |
+          eval "$(ssh-agent -t 300 -a "$RUNNER_TEMP/ssh-agent")"
+          echo "SSH_AGENT_PID=$SSH_AGENT_PID" | tee -a "$GITHUB_ENV"
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" | tee -a "$GITHUB_ENV"
+
+      - run: echo "$AUR_SSH_KEY" | ssh-add -
         env:
           AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
 
       - run: git subtree push "--prefix=$PACKAGE_NAME" "ssh://aur@aur.archlinux.org/$PACKAGE_NAME.git" master
         env:
-          GIT_SSH_COMMAND: ssh -i ~/.ssh/aur -o IdentitiesOnly=yes
           PACKAGE_NAME: ${{ matrix.package }}
+
+      - if: always() && steps.ssh-agent.outcome == 'success'
+        run: |
+          eval "$(ssh-agent -k)"
+          echo "SSH_AGENT_PID=$SSH_AGENT_PID" | tee -a "$GITHUB_ENV"
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" | tee -a "$GITHUB_ENV"


### PR DESCRIPTION
Avoid writing the key to the file system