### PR TITLE
Remove `typelib_installer` Meson option

### DIFF
--- a/gnome-shell-extension-ddterm-git/PKGBUILD
+++ b/gnome-shell-extension-ddterm-git/PKGBUILD
@@ -25,7 +25,6 @@ build() {
         -Dtests=disabled
         -Dtests_x11=disabled
         -Dtests_wl_clipboard=disabled
-        -Dtypelib_installer=false
     )
 
     arch-meson "${pkgname%-git}" build "${meson_options[@]}"


### PR DESCRIPTION
It's off by default, and it'll be removed soon.