### PR TITLE
renovate: use custom datasource instead of github-release-assets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,11 +28,18 @@
       "matchStrings": [
         "(pkgbase|pkgname)\\s*=\\s*['\"]?(?<depName>\\S+)[\\s\\S]*pkgver\\s*=\\s*['\"]?(?<currentValue>\\S+)[\\s\\S]*sha256sums\\s*=(\\s*\\()?\\s*['\"]?(?<currentDigest>\\w+)"
       ],
-      "datasourceTemplate": "github-release-attachments",
-      "packageNameTemplate": "ddterm/{{{ depName }}}",
-      "currentValueTemplate": "v{{{ currentValue }}}"
+      "datasourceTemplate": "custom.ddterm-release-tarball",
+      "versioningTemplate": "npm"
     }
   ],
+  "customDatasources": {
+    "ddterm-release-tarball": {
+      "defaultRegistryUrlTemplate": "https://api.github.com/repos/ddterm/gnome-shell-extension-ddterm/releases",
+      "transformTemplates": [
+        "{'releases':$[draft=false].{'version':$replace(tag_name,/^v/,''),'isStable':$not(prerelease),'digest':assets[$contains(name,/^ddterm-.*\\.tar\\.gz$/)].digest.($?$replace(/^sha256:/,''):null)}}"
+      ]
+    }
+  },
   "logLevelRemap": [
     {
       "matchMessage": "No dependencies found in file for custom regex manager",


### PR DESCRIPTION
github-release-assets can't handle 'v' prefix.