### PR TITLE
renovate: remove "to" from auto-release commit message

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,7 @@
       "matchDatasources": ["custom.ddterm-release-tarball"],
       "commitMessageTopic": "{{depName}}",
       "commitMessageAction": "Release",
+      "commitMessageExtra": "{{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
       "semanticCommitType": "feat",
       "semanticCommitScope": "pkg",
       "automerge": true


### PR DESCRIPTION
Copy and paste the default `commitMessageExtra` value from https://docs.renovatebot.com/configuration-options/#commitmessageextra and remove `to ` prefix from it